### PR TITLE
リストをlibに追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,10 @@ include_directories("${PROJECT_SOURCE_DIR}/src/include/")
 add_executable(manbomber-srv src/srv/srv.c src/srv/srv-master.c
 	src/srv/srv-slave.c src/lib/magic.c src/lib/recv-data.c)
 add_executable(srv_data_recv tests/srv_data_recv.c)
+add_executable(list tests/list.c src/lib/list.c)
 
 add_test(srv_data_recv ${EXECUTABLE_OUTPUT_PATH}/srv_data_recv)
+add_test(list ${EXECUTABLE_OUTPUT_PATH}/list)
 
 option(HOGE_FUGA "Return fuga\n to hoge\r\n" OFF)
 if(HOGE_FUGA)

--- a/src/include/list.h
+++ b/src/include/list.h
@@ -1,0 +1,17 @@
+#ifndef _LIST_H_
+#define _LIST_H_
+
+#define list_entry(type, node, member) \
+	((type *)((char *)(node)-(unsigned long)(&((type *)0)->member)))
+
+#define INIT_LIST_HEAD(x) \
+	(x)->next = NULL
+
+struct list_node {
+	struct list_node *next;
+};
+
+void list_add(struct list_node *entry, struct list_node *head);
+void list_remove(struct list_node *entry, struct list_node *head);
+
+#endif /* _LIST_H_ */

--- a/src/include/man_bomber.h
+++ b/src/include/man_bomber.h
@@ -3,6 +3,8 @@
 
 #include <stddef.h>
 
+#include "list.h"
+
 /* magic values with no particular meaning */
 #define PLA 0x18fabe0d
 #define BOM 0xdc3bae7b
@@ -72,12 +74,18 @@ struct bomb {
 
 	/* 0: dead, 1: alive */
 	int is_alive; 
+
+	/* Linked list node */
+	struct list_node node;
 };
 
 struct player {
 	int x;
 	int y;
 	int bombs;
+
+	/* Linked list node */
+	struct list_node node;
 };
 
 /* Destructable wall */
@@ -87,6 +95,9 @@ struct wall {
 
 	/* 0: dead, 1: alive */
 	int is_alive; 
+
+	/* Linked list node */
+	struct list_node node;
 };
 
 int check_magic(int fd, int magic);

--- a/src/lib/list.c
+++ b/src/lib/list.c
@@ -1,0 +1,18 @@
+#include "list.h"
+
+
+void list_add(struct list_node *entry, struct list_node *head)
+{
+	struct list_node *cur = head;
+	while (cur->next)
+		cur = cur->next;
+	cur->next = entry;
+}
+
+void list_remove(struct list_node *entry, struct list_node *head)
+{
+	struct list_node **cur = &head;
+	while (*cur != entry)
+		cur = &(*cur)->next;
+	*cur = (*cur)->next;
+}

--- a/tests/list.c
+++ b/tests/list.c
@@ -1,0 +1,35 @@
+#include <stdlib.h>
+#include "list.h"
+#include "man_bomber.h"
+
+int main()
+{
+	struct bomb b1;
+	struct bomb b2;
+	struct bomb b3;
+	struct bomb *p1;
+	struct bomb *p2;
+	struct bomb *p3;
+	struct list_node *head;
+	int ret = 0;
+	INIT_LIST_HEAD(&b1.node);
+	INIT_LIST_HEAD(&b2.node);
+	INIT_LIST_HEAD(&b3.node);
+	head = &b1.node;
+	b1.x = 1;
+	b2.x = 2;
+	b3.x = 3;
+	b1.y = 9;
+	b2.y = 8;
+	b3.y = 7;
+
+	list_add(&b2.node, head);
+	list_add(&b3.node, head);
+	p1 = list_entry(struct bomb, head, node);
+	p2 = list_entry(struct bomb, head->next, node);
+	p3 = list_entry(struct bomb, head->next->next, node);
+	if (p1 == &b1 && p2 == &b2 && p3 == &b3)
+		return 0;
+	else
+		return 1;
+}


### PR DESCRIPTION
- 構造体にlist_node型構造体をもたせる使い方をする
- 使い方はテストコードを参照
- 既存のデータ型のうち, ひつようのあるものはリストを使うように改変済み.
- リストのコードはメモリ管理に関与しない.
