### PR TITLE
list_add()に, リストの先頭がNULLの場合とそうでない場合の区別をなくす

### DIFF
--- a/src/include/list.h
+++ b/src/include/list.h
@@ -11,7 +11,7 @@ struct list_node {
 	struct list_node *next;
 };
 
-void list_add(struct list_node *entry, struct list_node *head);
+void list_add(struct list_node *entry, struct list_node **head);
 void list_remove(struct list_node *entry, struct list_node **head);
 
 #endif /* _LIST_H_ */

--- a/src/lib/list.c
+++ b/src/lib/list.c
@@ -2,12 +2,12 @@
 
 #include "list.h"
 
-void list_add(struct list_node *entry, struct list_node *head)
+void list_add(struct list_node *entry, struct list_node **head)
 {
-	struct list_node *cur = head;
-	while (cur->next)
-		cur = cur->next;
-	cur->next = entry;
+	struct list_node **cur = head;
+	while (*cur)
+		cur = &(*cur)->next;
+	*cur = entry;
 	entry->next = NULL;
 }
 

--- a/tests/list.c
+++ b/tests/list.c
@@ -23,8 +23,8 @@ int main()
 	b2.y = 8;
 	b3.y = 7;
 
-	list_add(&b2.node, head);
-	list_add(&b3.node, head);
+	list_add(&b2.node, &head);
+	list_add(&b3.node, &head);
 	p1 = list_entry(struct bomb, head, node);
 	p2 = list_entry(struct bomb, head->next, node);
 	p3 = list_entry(struct bomb, head->next->next, node);


### PR DESCRIPTION
- この変更により, リストの先頭を指すポインターがNULLの場合でも正しく動作するようになる.
- この変更により, リストの先頭は, 先頭へのポインターへのポインター(struct list_node **head)を渡すようになる.
